### PR TITLE
Adds `os` to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
       "url": "http://github.com/felixrieseberg/macos-notification-state/blob/master/LICENSE"
     }
   ],
+  "os": [
+    "darwin"
+  ],
   "dependencies": {
     "bindings": "^1.5.0"
   },


### PR DESCRIPTION
- prevent building on other than Darwin

https://docs.npmjs.com/cli/v7/configuring-npm/package-json#os