### PR TITLE
Fix Monterey breakage

### DIFF
--- a/lib/do-not-disturb.mm
+++ b/lib/do-not-disturb.mm
@@ -3,8 +3,8 @@
 bool getDoNotDisturb() {
   bool doNotDisturb;
   NSOperatingSystemVersion version = [[NSProcessInfo processInfo] operatingSystemVersion];
-  bool isBigSur = version.majorVersion == 11 || (version.majorVersion == 10 && version.minorVersion > 15);
-  if (isBigSur) {
+  bool isBigSurOrNewer = version.majorVersion >= 11 || (version.majorVersion == 10 && version.minorVersion > 15);
+  if (isBigSurOrNewer) {
     // On big sur we have to read a plist from a plist...
     NSData* dndData = [[[NSUserDefaults alloc] initWithSuiteName:@"com.apple.ncprefs"] dataForKey:@"dnd_prefs"];
     // If there is no DND data let's assume that we aren't in DND


### PR DESCRIPTION
Monterey uses major version 12, causing this version guard to fall into the pre-Big Sur case. Let's assume Monterey uses the same DnD plist as Big Sur.