### PR TITLE
Fix monterey detect DND status

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -5,7 +5,13 @@
       "sources": [ "lib/notificationstate.cc" ],
       "conditions": [
         ['OS=="mac"', {
-          "sources": ["lib/notificationstate-query.cc", "lib/do-not-disturb.mm"],
+          "sources": [
+            "lib/notificationstate-query.cc", 
+            "lib/do-not-disturb.mm", 
+            "lib/dnd/old-macos-dnd.mm", 
+            "lib/dnd/bigsur-macos-dnd.mm", 
+            "lib/dnd/monterey-macos-dnd.mm"
+          ],
           "xcode_settings": {
               "OTHER_CPLUSPLUSFLAGS": ["-std=c++17", "-stdlib=libc++", "-mmacosx-version-min=10.7"],
               "OTHER_LDFLAGS": ["-framework CoreFoundation -framework CoreGraphics"]

--- a/lib/dnd/bigsur-macos-dnd.h
+++ b/lib/dnd/bigsur-macos-dnd.h
@@ -1,0 +1,1 @@
+bool getBigSurMacOSDND();

--- a/lib/dnd/bigsur-macos-dnd.mm
+++ b/lib/dnd/bigsur-macos-dnd.mm
@@ -1,0 +1,69 @@
+#import <Foundation/Foundation.h>
+
+bool getBigSurMacOSDND() {
+  // On big sur we have to read a plist from a plist...
+  NSData *dndData = [[[NSUserDefaults alloc]
+      initWithSuiteName:@"com.apple.ncprefs"] dataForKey:@"dnd_prefs"];
+  // If there is no DND data let's assume that we aren't in DND
+  if (!dndData)
+    return false;
+
+  NSDictionary *dndDict =
+      [NSPropertyListSerialization propertyListWithData:dndData
+                                                options:NSPropertyListImmutable
+                                                 format:nil
+                                                  error:nil];
+  // If the dnd data isn't a valid plist, again assume we aren't in DND
+  if (!dndDict)
+    return false;
+  NSDictionary *userPrefs = [dndDict valueForKey:@"userPref"];
+  if (userPrefs) {
+    NSNumber *dndEnabled = [userPrefs valueForKey:@"enabled"];
+    // If the user pref has it set to enabled
+    if ([dndEnabled intValue] == 1)
+      return true;
+  }
+
+  NSDictionary *scheduledPrefs = [dndDict valueForKey:@"scheduledTime"];
+  if (scheduledPrefs) {
+    NSNumber *scheduleEnabled = [scheduledPrefs valueForKey:@"enabled"];
+    NSNumber *start = [scheduledPrefs valueForKey:@"start"];
+    NSNumber *end = [scheduledPrefs valueForKey:@"end"];
+    // If the schedule is enabled, we need to manually determine if we fall in
+    // the start / end interval
+    if ([scheduleEnabled intValue] == 1 && start && end) {
+      NSDate *now = [NSDate date];
+      NSCalendar *calendar = [NSCalendar currentCalendar];
+      NSDateComponents *components =
+          [calendar components:(NSCalendarUnitHour | NSCalendarUnitMinute)
+                      fromDate:now];
+      NSInteger hour = [components hour];
+      NSInteger minute = [components minute];
+      NSInteger current = (hour * 60) + minute;
+
+      NSInteger startInt = [start intValue];
+      NSInteger endInt = [end intValue];
+      // Normal way round, start is before the end
+      if (startInt < endInt) {
+        // Start is inclusive, end is exclusive
+        if (current >= startInt && current < endInt)
+          return true;
+      } else if (endInt < startInt) {
+        // The end can also be _after_ the start making the DND interval loop
+        // over midnight
+        if (current >= startInt)
+          return true;
+        if (current < endInt)
+          return true;
+      }
+    }
+  }
+
+  // TODO: Support and check the follow dndDict keys
+  // - dndDisplaySleep
+  // - dndDisplayLock
+  // - dndMirrored
+
+  // Not manually enabled, not enabled due to schedule
+  return false;
+}

--- a/lib/dnd/monterey-macos-dnd.h
+++ b/lib/dnd/monterey-macos-dnd.h
@@ -1,0 +1,9 @@
+#import <Foundation/Foundation.h>
+
+@interface MontereyDND : NSObject
++ (bool)isEnabled;
++ (bool)enabledByAssertion;
++ (bool)enabledBySchedule;
++ (bool)allowedForBundleId;
++ (NSDictionary*)readJSONData:(NSString*)filePath;
+@end

--- a/lib/dnd/monterey-macos-dnd.mm
+++ b/lib/dnd/monterey-macos-dnd.mm
@@ -1,0 +1,162 @@
+#import "monterey-macos-dnd.h"
+#import <Foundation/Foundation.h>
+
+@implementation MontereyDND
++ (bool)isEnabled {
+  // Focus Preferences: ~/Library/DoNotDisturb/DB/ immediately updates
+  // Assertion.json - DND on/off -
+  // ModeConfiguration.json - Scheduled config stored
+  // ModeConfigurationSecure.json - Contains Apps allowed in DND mode
+
+  // 1. check assertion
+  bool isDNDEnabled = [self enabledByAssertion];
+  if (!isDNDEnabled) {
+    // 2. check schedule config
+    isDNDEnabled = [self enabledBySchedule];
+  }
+
+  if (isDNDEnabled) {
+    // 3 additional check is bundleIdentifier allowed while DND is on
+    bool isBundleIdAllowedInDND = [self allowedForBundleId];
+    // DND is "off" for current application
+    isDNDEnabled = !isBundleIdAllowedInDND;
+  }
+  return isDNDEnabled;
+}
+
++ (bool)allowedForBundleId {
+  NSString *bundleIdentifier = [[NSBundle mainBundle] bundleIdentifier];
+  if (bundleIdentifier) {
+    NSDictionary *modeConfigSecureDict =
+        [self readJSONData:
+                  @"~/Library/DoNotDisturb/DB/ModeConfigurationsSecure.json"];
+    NSDictionary *allowedApps = [[[[[[modeConfigSecureDict valueForKey:@"data"]
+        objectAtIndex:0] valueForKey:@"secureModeConfigurations"]
+        valueForKey:@"com.apple.donotdisturb.mode.default"]
+        valueForKey:@"secureConfiguration"] valueForKey:@"allowedApplications"];
+
+    if (!allowedApps)
+      return false;
+
+    NSDictionary *byBundle = [allowedApps valueForKey:bundleIdentifier];
+    if (byBundle) {
+      return true;
+    }
+    // try predicate - for case if bundle is child process
+    NSPredicate *predicate =
+        [NSPredicate predicateWithFormat:@"%@ CONTAINS SELF", bundleIdentifier];
+    NSArray *apps =
+        [[allowedApps allKeys] filteredArrayUsingPredicate:predicate];
+    if ([apps count] > 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
++ (bool)enabledByAssertion {
+  NSDictionary *assertDict =
+      [self readJSONData:@"~/Library/DoNotDisturb/DB/Assertions.json"];
+
+  if (!assertDict) {
+    return false;
+  }
+
+  NSDictionary *assertionData =
+      [[assertDict valueForKey:@"data"] objectAtIndex:0];
+  NSArray *storeAssertionRecords =
+      [assertionData valueForKey:@"storeAssertionRecords"];
+  // has active assertion - DND is ON
+  if (storeAssertionRecords) {
+    // TODO: can be improved by add compare timestamp of assertion with header
+    int size = [storeAssertionRecords count];
+    if (size > 0)
+      return true;
+  }
+  return false;
+}
+
++ (NSDictionary *)readJSONData:(NSString *)filePath {
+  NSString *fullPath = [filePath stringByExpandingTildeInPath];
+  NSError *error = nil;
+  NSData *jsonData = [NSData dataWithContentsOfFile:fullPath
+                                            options:kNilOptions
+                                              error:&error];
+  if (error) {
+    NSLog(@"Failed to open %s, error %@", fullPath, error);
+    return nil;
+  }
+
+  NSDictionary *parsedDictionary =
+      [NSJSONSerialization JSONObjectWithData:jsonData
+                                      options:kNilOptions
+                                        error:&error];
+  if (error) {
+    NSLog(@"Failed to parse dict %s, error %@", fullPath, error);
+    return nil;
+  }
+
+  return parsedDictionary;
+}
+
++ (bool)enabledBySchedule {
+  NSDictionary *modeConfigDict =
+      [self readJSONData:@"~/Library/DoNotDisturb/DB/ModeConfigurations.json"];
+
+  bool hasActiveTrigger = false;
+  NSArray *triggers = [[[[[[modeConfigDict valueForKey:@"data"] objectAtIndex:0]
+      valueForKey:@"modeConfigurations"]
+      valueForKey:@"com.apple.donotdisturb.mode.default"]
+      valueForKey:@"triggers"] valueForKey:@"triggers"];
+  if (triggers) {
+    if ([triggers count] == 0) {
+      return hasActiveTrigger;
+    }
+    NSDate *now = [NSDate date];
+    NSCalendar *calendar = [NSCalendar currentCalendar];
+    NSDateComponents *components =
+        [calendar components:(NSCalendarUnitHour | NSCalendarUnitMinute)
+                    fromDate:now];
+    NSInteger hour = [components hour];
+    NSInteger minute = [components minute];
+    NSInteger currentMinutes = (hour * 60) + minute;
+
+    for (NSDictionary *item in triggers) {
+      NSNumber *enabledSetting = [item valueForKey:@"enabledSetting"];
+      if ([enabledSetting intValue] == 2) {
+        // If the schedule is enabled, we need to manually determine if we fall
+        // in the start / end interval
+        NSNumber *startHour = [item valueForKey:@"timePeriodStartTimeHour"];
+        NSNumber *endHour = [item valueForKey:@"timePeriodEndTimeHour"];
+        NSNumber *startMinutesSetting =
+            [item valueForKey:@"timePeriodStartTimeMinute"];
+        if (startHour && endHour) {
+          NSInteger startMinutes =
+              [startHour intValue] * 60 + [startMinutesSetting intValue];
+          NSInteger endMinutes = [endHour intValue] * 60;
+          // Normal way round, start is before the end
+          if (startMinutes < endMinutes) {
+            // Start is inclusive, end is exclusive
+            if (currentMinutes >= startMinutes && currentMinutes < endMinutes) {
+              hasActiveTrigger = true;
+            }
+          } else if (endMinutes < startMinutes) {
+            // The end can also be _after_ the start making the DND interval
+            // loop over midnight
+            if (currentMinutes >= startMinutes || currentMinutes < endMinutes) {
+              hasActiveTrigger = true;
+            }
+          }
+        }
+      }
+    }
+  }
+  // not enabled due to schedule
+  return hasActiveTrigger;
+}
+
++ (id)alloc {
+  [NSException raise:@"Cannot be instantiated"];
+  return nil;
+}
+@end

--- a/lib/dnd/old-macos-dnd.h
+++ b/lib/dnd/old-macos-dnd.h
@@ -1,0 +1,1 @@
+bool getOldMacOSDND();

--- a/lib/dnd/old-macos-dnd.mm
+++ b/lib/dnd/old-macos-dnd.mm
@@ -1,0 +1,7 @@
+#import <Foundation/Foundation.h>
+
+bool getOldMacOSDND() {
+  return [[[[NSUserDefaults alloc]
+      initWithSuiteName:@"com.apple.notificationcenterui"]
+      objectForKey:@"doNotDisturb"] boolValue];
+}

--- a/lib/do-not-disturb.mm
+++ b/lib/do-not-disturb.mm
@@ -1,3 +1,6 @@
+#import "dnd/bigsur-macos-dnd.h"
+#import "dnd/monterey-macos-dnd.h"
+#import "dnd/old-macos-dnd.h"
 #import <Foundation/Foundation.h>
 
 bool getDoNotDisturb() {
@@ -7,201 +10,16 @@ bool getDoNotDisturb() {
                   (version.majorVersion == 10 && version.minorVersion > 15);
   bool isMonterey = version.majorVersion == 12;
 
-  if (isBigSur) {
-    NSLog(@"MacOS BigSur detected");
-    // On big sur we have to read a plist from a plist...
-    NSData *dndData = [[[NSUserDefaults alloc]
-        initWithSuiteName:@"com.apple.ncprefs"] dataForKey:@"dnd_prefs"];
-    // If there is no DND data let's assume that we aren't in DND
-    if (!dndData)
-      return false;
-
-    NSDictionary *dndDict = [NSPropertyListSerialization
-        propertyListWithData:dndData
-                     options:NSPropertyListImmutable
-                      format:nil
-                       error:nil];
-    // If the dnd data isn't a valid plist, again assume we aren't in DND
-    if (!dndDict)
-      return false;
-    NSDictionary *userPrefs = [dndDict valueForKey:@"userPref"];
-    if (userPrefs) {
-      NSNumber *dndEnabled = [userPrefs valueForKey:@"enabled"];
-      // If the user pref has it set to enabled
-      if ([dndEnabled intValue] == 1)
-        return true;
+  @try {
+    if (isBigSur) {
+      return getBigSurMacOSDND();
+    } else if (isMonterey) {
+      return [MontereyDND isEnabled];
+    } else {
+      return getOldMacOSDND();
     }
-
-    NSDictionary *scheduledPrefs = [dndDict valueForKey:@"scheduledTime"];
-    if (scheduledPrefs) {
-      NSNumber *scheduleEnabled = [scheduledPrefs valueForKey:@"enabled"];
-      NSNumber *start = [scheduledPrefs valueForKey:@"start"];
-      NSNumber *end = [scheduledPrefs valueForKey:@"end"];
-      // If the schedule is enabled, we need to manually determine if we fall in
-      // the start / end interval
-      if ([scheduleEnabled intValue] == 1 && start && end) {
-        NSDate *now = [NSDate date];
-        NSCalendar *calendar = [NSCalendar currentCalendar];
-        NSDateComponents *components =
-            [calendar components:(NSCalendarUnitHour | NSCalendarUnitMinute)
-                        fromDate:now];
-        NSInteger hour = [components hour];
-        NSInteger minute = [components minute];
-        NSInteger current = (hour * 60) + minute;
-
-        NSInteger startInt = [start intValue];
-        NSInteger endInt = [end intValue];
-        // Normal way round, start is before the end
-        if (startInt < endInt) {
-          // Start is inclusive, end is exclusive
-          if (current >= startInt && current < endInt)
-            return true;
-        } else if (endInt < startInt) {
-          // The end can also be _after_ the start making the DND interval loop
-          // over midnight
-          if (current >= startInt)
-            return true;
-          if (current < endInt)
-            return true;
-        }
-      }
-    }
-
-    // TODO: Support and check the follow dndDict keys
-    // - dndDisplaySleep
-    // - dndDisplayLock
-    // - dndMirrored
-
-    // Not manually enabled, not enabled due to schedule
-    return false;
-  } else if (isMonterey) {
-    @try {
-      NSLog(@"MacOS Monterey detected");
-      // there are two places that changed immediately after you change DND related stuff 
-      // Folder: ~/Library/DoNotDisturb/DB/ 
-      // Assertion.json - DND on/off - without scheduled time 
-      // ModeConfiguration.json - Scheduled config stored here
-
-      NSString *assertionFilePath =
-          [@"~/Library/DoNotDisturb/DB/Assertions.json"
-              stringByExpandingTildeInPath];
-      NSError *error = nil;
-      NSData *AssertJSONData =
-          [NSData dataWithContentsOfFile:assertionFilePath
-                                 options:NSDataReadingMappedIfSafe
-                                   error:&error];
-      if (error) {
-        NSLog(@"Failed to open assertions, error %@", error);
-        return false;
-      }
-
-      NSDictionary *assertDict =
-          [NSJSONSerialization JSONObjectWithData:AssertJSONData
-                                          options:NSJSONReadingAllowFragments
-                                            error:&error];
-      if (error) {
-        NSLog(@"Failed to parse assertions, error %@", error);
-        return false;
-      }
-
-      NSDictionary *assertionData =
-          [[assertDict valueForKey:@"data"] objectAtIndex:0];
-      NSArray *storeAssertionRecords =
-          [assertionData valueForKey:@"storeAssertionRecords"];
-      // has active assertion - DND is ON
-      if (storeAssertionRecords) {
-        // TODO: can be improved by add compare timestamp of assertion with
-        // header
-        int size = [storeAssertionRecords count];
-        if (size > 0)
-          return true;
-      }
-
-      // go and try check schedule
-      NSString *modeConfigFilePath =
-          [@"~/Library/DoNotDisturb/DB/ModeConfigurations.json"
-              stringByExpandingTildeInPath];
-      NSData *ModeConfigJSONData =
-          [NSData dataWithContentsOfFile:modeConfigFilePath
-                                 options:NSDataReadingMappedIfSafe
-                                   error:&error];
-      if (error) {
-        NSLog(@"Failed to open modeConfiguration, error %@", error);
-        return false;
-      }
-
-      NSDictionary *modeConfigDict =
-          [NSJSONSerialization JSONObjectWithData:ModeConfigJSONData
-                                          options:kNilOptions
-                                            error:&error];
-      if (error) {
-        NSLog(@"Failed to parse modeConfiguration, error %@", error);
-        return false;
-      }
-
-      bool hasActiveTrigger = false;
-      NSArray *triggers = [[[[[[modeConfigDict valueForKey:@"data"]
-          objectAtIndex:0] valueForKey:@"modeConfigurations"]
-          valueForKey:@"com.apple.donotdisturb.mode.default"]
-          valueForKey:@"triggers"] valueForKey:@"triggers"];
-      if (triggers) {
-        if ([triggers count] == 0) {
-          NSLog(@"Triggers are empty");
-          return hasActiveTrigger;
-        }
-        NSDate *now = [NSDate date];
-        NSCalendar *calendar = [NSCalendar currentCalendar];
-        NSDateComponents *components =
-            [calendar components:(NSCalendarUnitHour | NSCalendarUnitMinute)
-                        fromDate:now];
-        NSInteger hour = [components hour];
-        NSInteger minute = [components minute];
-        NSInteger currentMinutes = (hour * 60) + minute;
-
-        for (NSDictionary *item in triggers) {
-          NSNumber *enabledSetting = [item valueForKey:@"enabledSetting"];
-          if ([enabledSetting intValue] == 2) {
-            // If the schedule is enabled, we need to manually determine if we
-            // fall in the start / end interval
-            NSNumber *startHour = [item valueForKey:@"timePeriodStartTimeHour"];
-            NSNumber *endHour = [item valueForKey:@"timePeriodEndTimeHour"];
-            NSNumber *startMinutesSetting =
-                [item valueForKey:@"timePeriodStartTimeMinute"];
-            if (startHour && endHour) {
-              NSInteger startMinutes =
-                  [startHour intValue] * 60 + [startMinutesSetting intValue];
-              NSInteger endMinutes = [endHour intValue] * 60;
-              NSLog(@"Found enabled trigger: StartMinutes: %ld, EndMinutes: "
-                    @"%ld, currentMinutes: %ld",
-                    startMinutes, endMinutes, currentMinutes);
-              // Normal way round, start is before the end
-              if (startMinutes < endMinutes) {
-                // Start is inclusive, end is exclusive
-                if (currentMinutes >= startMinutes &&
-                    currentMinutes < endMinutes) {
-                  hasActiveTrigger = true;
-                }
-              } else if (endMinutes < startMinutes) {
-                // The end can also be _after_ the start making the DND interval
-                // loop over midnight
-                if (currentMinutes >= startMinutes ||
-                    currentMinutes < endMinutes) {
-                  hasActiveTrigger = true;
-                }
-              }
-            }
-          }
-        }
-      }
-      // Not manually enabled, not enabled due to schedule
-      return hasActiveTrigger;
-    } @catch (NSException *error) {
-      NSLog(@"Failed to detect DND status: %@", error);
-    }
-    return false;
+  } @catch (NSException *error) {
+    NSLog(@"Failed to detect DND status: %@", error);
   }
-  NSLog(@"MacOS prior BigSur(Mohave, Catalina, ...) detected");
-  return [[[[NSUserDefaults alloc]
-      initWithSuiteName:@"com.apple.notificationcenterui"]
-      objectForKey:@"doNotDisturb"] boolValue];
+  return false;
 }

--- a/lib/do-not-disturb.mm
+++ b/lib/do-not-disturb.mm
@@ -1,10 +1,12 @@
 #import <Foundation/Foundation.h>
 
 bool getDoNotDisturb() {
-  bool doNotDisturb;
   NSOperatingSystemVersion version = [[NSProcessInfo processInfo] operatingSystemVersion];
-  bool isBigSurOrNewer = version.majorVersion >= 11 || (version.majorVersion == 10 && version.minorVersion > 15);
-  if (isBigSurOrNewer) {
+  bool isBigSur = version.majorVersion == 11 || (version.majorVersion == 10 && version.minorVersion > 15);
+  bool isMonterey = version.majorVersion == 12;
+
+  if (isBigSur) {
+    NSLog(@"MacOS BigSur detected");
     // On big sur we have to read a plist from a plist...
     NSData* dndData = [[[NSUserDefaults alloc] initWithSuiteName:@"com.apple.ncprefs"] dataForKey:@"dnd_prefs"];
     // If there is no DND data let's assume that we aren't in DND
@@ -17,7 +19,6 @@ bool getDoNotDisturb() {
                            error:nil];
     // If the dnd data isn't a valid plist, again assume we aren't in DND
     if (!dndDict) return false;
-
     NSDictionary* userPrefs = [dndDict valueForKey:@"userPref"];
     if (userPrefs) {
       NSNumber* dndEnabled = [userPrefs valueForKey:@"enabled"];
@@ -60,9 +61,102 @@ bool getDoNotDisturb() {
 
     // Not manually enabled, not enabled due to schedule
     return false;
-  } else {
-    // Older than big sur we can just read the pref directly
-    doNotDisturb = [[[[NSUserDefaults alloc] initWithSuiteName:@"com.apple.notificationcenterui"] objectForKey:@"doNotDisturb"] boolValue];
-  }
-  return doNotDisturb;
+  } else if (isMonterey) {
+    // TODO: add try catch
+    NSLog(@"MacOS Monterey detected");
+    // there are two places that changed immediately after you change DND stuff
+    // Folder: ~/Library/DoNotDisturb/DB/
+    // Assertion.json - DND on/off - without scheduled time
+    // ModeConfiguration.json - Scheduled config stored here
+
+    NSString* assertionFilePath = [@"~/Library/DoNotDisturb/DB/Assertions.json" stringByExpandingTildeInPath];
+    NSError* error = nil;
+    NSData* AssertJSONData = [NSData dataWithContentsOfFile:assertionFilePath options:NSDataReadingMappedIfSafe error:&error];
+    if (error) {
+     NSLog(@"Failed to open assertions, error %@", error);
+     return false;
+    }
+
+    NSDictionary* assertDict = [NSJSONSerialization
+                         JSONObjectWithData:AssertJSONData
+                         options:NSJSONReadingAllowFragments
+                         error:&error];
+    if (error) {
+     NSLog(@"Failed to parse assertions, error %@", error);
+     return false;
+    }
+
+    NSDictionary* assertionData = [[assertDict valueForKey:@"data"] objectAtIndex:0];
+    NSArray* storeAssertionRecords = [assertionData valueForKey:@"storeAssertionRecords"];
+    // has active assertion - DND is ON
+    if (storeAssertionRecords) {
+       // TODO: can be improved by add compare timestamp of assertion with header
+      int size = [storeAssertionRecords count]; 
+      if (size > 0) return true;
+    }
+    
+    // go and try check schedule
+    NSString* modeConfigFilePath = [@"~/Library/DoNotDisturb/DB/ModeConfigurations.json" stringByExpandingTildeInPath];
+    NSData* ModeConfigJSONData = [NSData dataWithContentsOfFile:modeConfigFilePath options:NSDataReadingMappedIfSafe error:&error];
+    if (error) {
+     NSLog(@"Failed to open modeConfiguration, error %@", error);
+     return false;
+    }
+
+    NSDictionary* modeConfigDict = [NSJSONSerialization
+                         JSONObjectWithData:ModeConfigJSONData
+                         options:kNilOptions
+                         error:&error];
+    if (error) {
+     NSLog(@"Failed to parse modeConfiguration, error %@", error);
+     return false;
+    }
+
+
+    bool hasActiveTrigger = false;
+    NSArray* triggers = [[[[[[modeConfigDict valueForKey:@"data"] objectAtIndex:0] valueForKey:@"modeConfigurations"] valueForKey:@"com.apple.donotdisturb.mode.default"] valueForKey:@"triggers"] valueForKey:@"triggers"];
+    if (triggers) {
+      if ([triggers count] == 0) {
+        NSLog(@"Triggers are empty");
+        return hasActiveTrigger;
+      }
+      NSDate* now = [NSDate date];
+      NSCalendar *calendar = [NSCalendar currentCalendar];
+      NSDateComponents *components = [calendar components:(NSCalendarUnitHour | NSCalendarUnitMinute) fromDate:now];
+      NSInteger hour = [components hour];
+      NSInteger minute = [components minute];
+      NSInteger currentMinutes = (hour * 60) + minute;
+
+      for (NSDictionary *item in triggers) {
+        NSNumber* enabledSetting = [item valueForKey:@"enabledSetting"];
+        if ([enabledSetting intValue] == 2) {
+          // If the schedule is enabled, we need to manually determine if we fall in the start / end interval
+          NSNumber* startHour = [item valueForKey:@"timePeriodStartTimeHour"];
+          NSNumber* endHour = [item valueForKey:@"timePeriodEndTimeHour"];
+          NSNumber* startMinutesSetting = [item valueForKey:@"timePeriodStartTimeMinute"];
+          if (startHour && endHour) {
+            NSInteger startMinutes = [startHour intValue] * 60 + [startMinutesSetting intValue];
+            NSInteger endMinutes = [endHour intValue] * 60;
+            NSLog(@"Found enabled trigger: StartMinutes: %ld, EndMinutes: %ld, currentMinutes: %ld", startMinutes, endMinutes, currentMinutes);
+            // Normal way round, start is before the end
+            if (startMinutes < endMinutes) {
+              // Start is inclusive, end is exclusive
+              if (currentMinutes >= startMinutes && currentMinutes < endMinutes) {
+                hasActiveTrigger = true;
+              }
+            } else if (endMinutes < startMinutes) {
+              // The end can also be _after_ the start making the DND interval loop over midnight
+              if (currentMinutes >= startMinutes || currentMinutes < endMinutes) {
+                hasActiveTrigger = true;
+              }
+            }
+          }
+        }
+      }
+    }
+    // Not manually enabled, not enabled due to schedule
+    return hasActiveTrigger;
+  } 
+  NSLog(@"MacOS prior BigSur(Mohave, Catalina, ...) detected");
+  return [[[[NSUserDefaults alloc] initWithSuiteName:@"com.apple.notificationcenterui"] objectForKey:@"doNotDisturb"] boolValue];
 }

--- a/lib/do-not-disturb.mm
+++ b/lib/do-not-disturb.mm
@@ -1,41 +1,50 @@
 #import <Foundation/Foundation.h>
 
 bool getDoNotDisturb() {
-  NSOperatingSystemVersion version = [[NSProcessInfo processInfo] operatingSystemVersion];
-  bool isBigSur = version.majorVersion == 11 || (version.majorVersion == 10 && version.minorVersion > 15);
+  NSOperatingSystemVersion version =
+      [[NSProcessInfo processInfo] operatingSystemVersion];
+  bool isBigSur = version.majorVersion == 11 ||
+                  (version.majorVersion == 10 && version.minorVersion > 15);
   bool isMonterey = version.majorVersion == 12;
 
   if (isBigSur) {
     NSLog(@"MacOS BigSur detected");
     // On big sur we have to read a plist from a plist...
-    NSData* dndData = [[[NSUserDefaults alloc] initWithSuiteName:@"com.apple.ncprefs"] dataForKey:@"dnd_prefs"];
+    NSData *dndData = [[[NSUserDefaults alloc]
+        initWithSuiteName:@"com.apple.ncprefs"] dataForKey:@"dnd_prefs"];
     // If there is no DND data let's assume that we aren't in DND
-    if (!dndData) return false;
+    if (!dndData)
+      return false;
 
-    NSDictionary* dndDict = [NSPropertyListSerialization
-            propertyListWithData:dndData
-                         options:NSPropertyListImmutable
-                          format:nil
-                           error:nil];
+    NSDictionary *dndDict = [NSPropertyListSerialization
+        propertyListWithData:dndData
+                     options:NSPropertyListImmutable
+                      format:nil
+                       error:nil];
     // If the dnd data isn't a valid plist, again assume we aren't in DND
-    if (!dndDict) return false;
-    NSDictionary* userPrefs = [dndDict valueForKey:@"userPref"];
+    if (!dndDict)
+      return false;
+    NSDictionary *userPrefs = [dndDict valueForKey:@"userPref"];
     if (userPrefs) {
-      NSNumber* dndEnabled = [userPrefs valueForKey:@"enabled"];
+      NSNumber *dndEnabled = [userPrefs valueForKey:@"enabled"];
       // If the user pref has it set to enabled
-      if ([dndEnabled intValue] == 1) return true;
+      if ([dndEnabled intValue] == 1)
+        return true;
     }
 
-    NSDictionary* scheduledPrefs = [dndDict valueForKey:@"scheduledTime"];
+    NSDictionary *scheduledPrefs = [dndDict valueForKey:@"scheduledTime"];
     if (scheduledPrefs) {
-      NSNumber* scheduleEnabled = [scheduledPrefs valueForKey:@"enabled"];
-      NSNumber* start = [scheduledPrefs valueForKey:@"start"];
-      NSNumber* end = [scheduledPrefs valueForKey:@"end"];
-      // If the schedule is enabled, we need to manually determine if we fall in the start / end interval
+      NSNumber *scheduleEnabled = [scheduledPrefs valueForKey:@"enabled"];
+      NSNumber *start = [scheduledPrefs valueForKey:@"start"];
+      NSNumber *end = [scheduledPrefs valueForKey:@"end"];
+      // If the schedule is enabled, we need to manually determine if we fall in
+      // the start / end interval
       if ([scheduleEnabled intValue] == 1 && start && end) {
-        NSDate* now = [NSDate date];
+        NSDate *now = [NSDate date];
         NSCalendar *calendar = [NSCalendar currentCalendar];
-        NSDateComponents *components = [calendar components:(NSCalendarUnitHour | NSCalendarUnitMinute) fromDate:now];
+        NSDateComponents *components =
+            [calendar components:(NSCalendarUnitHour | NSCalendarUnitMinute)
+                        fromDate:now];
         NSInteger hour = [components hour];
         NSInteger minute = [components minute];
         NSInteger current = (hour * 60) + minute;
@@ -45,11 +54,15 @@ bool getDoNotDisturb() {
         // Normal way round, start is before the end
         if (startInt < endInt) {
           // Start is inclusive, end is exclusive
-          if (current >= startInt && current < endInt) return true;
+          if (current >= startInt && current < endInt)
+            return true;
         } else if (endInt < startInt) {
-          // The end can also be _after_ the start making the DND interval loop over midnight
-          if (current >= startInt) return true;
-          if (current < endInt) return true;
+          // The end can also be _after_ the start making the DND interval loop
+          // over midnight
+          if (current >= startInt)
+            return true;
+          if (current < endInt)
+            return true;
         }
       }
     }
@@ -64,89 +77,115 @@ bool getDoNotDisturb() {
   } else if (isMonterey) {
     @try {
       NSLog(@"MacOS Monterey detected");
-      // there are two places that changed immediately after you change DND related stuff
-      // Folder: ~/Library/DoNotDisturb/DB/
-      // Assertion.json - DND on/off - without scheduled time
+      // there are two places that changed immediately after you change DND related stuff 
+      // Folder: ~/Library/DoNotDisturb/DB/ 
+      // Assertion.json - DND on/off - without scheduled time 
       // ModeConfiguration.json - Scheduled config stored here
 
-      NSString* assertionFilePath = [@"~/Library/DoNotDisturb/DB/Assertions.json" stringByExpandingTildeInPath];
-      NSError* error = nil;
-      NSData* AssertJSONData = [NSData dataWithContentsOfFile:assertionFilePath options:NSDataReadingMappedIfSafe error:&error];
+      NSString *assertionFilePath =
+          [@"~/Library/DoNotDisturb/DB/Assertions.json"
+              stringByExpandingTildeInPath];
+      NSError *error = nil;
+      NSData *AssertJSONData =
+          [NSData dataWithContentsOfFile:assertionFilePath
+                                 options:NSDataReadingMappedIfSafe
+                                   error:&error];
       if (error) {
-      NSLog(@"Failed to open assertions, error %@", error);
-      return false;
+        NSLog(@"Failed to open assertions, error %@", error);
+        return false;
       }
 
-      NSDictionary* assertDict = [NSJSONSerialization
-                          JSONObjectWithData:AssertJSONData
-                          options:NSJSONReadingAllowFragments
-                          error:&error];
+      NSDictionary *assertDict =
+          [NSJSONSerialization JSONObjectWithData:AssertJSONData
+                                          options:NSJSONReadingAllowFragments
+                                            error:&error];
       if (error) {
-      NSLog(@"Failed to parse assertions, error %@", error);
-      return false;
+        NSLog(@"Failed to parse assertions, error %@", error);
+        return false;
       }
 
-      NSDictionary* assertionData = [[assertDict valueForKey:@"data"] objectAtIndex:0];
-      NSArray* storeAssertionRecords = [assertionData valueForKey:@"storeAssertionRecords"];
+      NSDictionary *assertionData =
+          [[assertDict valueForKey:@"data"] objectAtIndex:0];
+      NSArray *storeAssertionRecords =
+          [assertionData valueForKey:@"storeAssertionRecords"];
       // has active assertion - DND is ON
       if (storeAssertionRecords) {
-        // TODO: can be improved by add compare timestamp of assertion with header
-        int size = [storeAssertionRecords count]; 
-        if (size > 0) return true;
+        // TODO: can be improved by add compare timestamp of assertion with
+        // header
+        int size = [storeAssertionRecords count];
+        if (size > 0)
+          return true;
       }
-      
+
       // go and try check schedule
-      NSString* modeConfigFilePath = [@"~/Library/DoNotDisturb/DB/ModeConfigurations.json" stringByExpandingTildeInPath];
-      NSData* ModeConfigJSONData = [NSData dataWithContentsOfFile:modeConfigFilePath options:NSDataReadingMappedIfSafe error:&error];
+      NSString *modeConfigFilePath =
+          [@"~/Library/DoNotDisturb/DB/ModeConfigurations.json"
+              stringByExpandingTildeInPath];
+      NSData *ModeConfigJSONData =
+          [NSData dataWithContentsOfFile:modeConfigFilePath
+                                 options:NSDataReadingMappedIfSafe
+                                   error:&error];
       if (error) {
         NSLog(@"Failed to open modeConfiguration, error %@", error);
         return false;
       }
 
-      NSDictionary* modeConfigDict = [NSJSONSerialization
-                          JSONObjectWithData:ModeConfigJSONData
-                          options:kNilOptions
-                          error:&error];
+      NSDictionary *modeConfigDict =
+          [NSJSONSerialization JSONObjectWithData:ModeConfigJSONData
+                                          options:kNilOptions
+                                            error:&error];
       if (error) {
         NSLog(@"Failed to parse modeConfiguration, error %@", error);
         return false;
       }
 
-
       bool hasActiveTrigger = false;
-      NSArray* triggers = [[[[[[modeConfigDict valueForKey:@"data"] objectAtIndex:0] valueForKey:@"modeConfigurations"] valueForKey:@"com.apple.donotdisturb.mode.default"] valueForKey:@"triggers"] valueForKey:@"triggers"];
+      NSArray *triggers = [[[[[[modeConfigDict valueForKey:@"data"]
+          objectAtIndex:0] valueForKey:@"modeConfigurations"]
+          valueForKey:@"com.apple.donotdisturb.mode.default"]
+          valueForKey:@"triggers"] valueForKey:@"triggers"];
       if (triggers) {
         if ([triggers count] == 0) {
           NSLog(@"Triggers are empty");
           return hasActiveTrigger;
         }
-        NSDate* now = [NSDate date];
+        NSDate *now = [NSDate date];
         NSCalendar *calendar = [NSCalendar currentCalendar];
-        NSDateComponents *components = [calendar components:(NSCalendarUnitHour | NSCalendarUnitMinute) fromDate:now];
+        NSDateComponents *components =
+            [calendar components:(NSCalendarUnitHour | NSCalendarUnitMinute)
+                        fromDate:now];
         NSInteger hour = [components hour];
         NSInteger minute = [components minute];
         NSInteger currentMinutes = (hour * 60) + minute;
 
         for (NSDictionary *item in triggers) {
-          NSNumber* enabledSetting = [item valueForKey:@"enabledSetting"];
+          NSNumber *enabledSetting = [item valueForKey:@"enabledSetting"];
           if ([enabledSetting intValue] == 2) {
-            // If the schedule is enabled, we need to manually determine if we fall in the start / end interval
-            NSNumber* startHour = [item valueForKey:@"timePeriodStartTimeHour"];
-            NSNumber* endHour = [item valueForKey:@"timePeriodEndTimeHour"];
-            NSNumber* startMinutesSetting = [item valueForKey:@"timePeriodStartTimeMinute"];
+            // If the schedule is enabled, we need to manually determine if we
+            // fall in the start / end interval
+            NSNumber *startHour = [item valueForKey:@"timePeriodStartTimeHour"];
+            NSNumber *endHour = [item valueForKey:@"timePeriodEndTimeHour"];
+            NSNumber *startMinutesSetting =
+                [item valueForKey:@"timePeriodStartTimeMinute"];
             if (startHour && endHour) {
-              NSInteger startMinutes = [startHour intValue] * 60 + [startMinutesSetting intValue];
+              NSInteger startMinutes =
+                  [startHour intValue] * 60 + [startMinutesSetting intValue];
               NSInteger endMinutes = [endHour intValue] * 60;
-              NSLog(@"Found enabled trigger: StartMinutes: %ld, EndMinutes: %ld, currentMinutes: %ld", startMinutes, endMinutes, currentMinutes);
+              NSLog(@"Found enabled trigger: StartMinutes: %ld, EndMinutes: "
+                    @"%ld, currentMinutes: %ld",
+                    startMinutes, endMinutes, currentMinutes);
               // Normal way round, start is before the end
               if (startMinutes < endMinutes) {
                 // Start is inclusive, end is exclusive
-                if (currentMinutes >= startMinutes && currentMinutes < endMinutes) {
+                if (currentMinutes >= startMinutes &&
+                    currentMinutes < endMinutes) {
                   hasActiveTrigger = true;
                 }
               } else if (endMinutes < startMinutes) {
-                // The end can also be _after_ the start making the DND interval loop over midnight
-                if (currentMinutes >= startMinutes || currentMinutes < endMinutes) {
+                // The end can also be _after_ the start making the DND interval
+                // loop over midnight
+                if (currentMinutes >= startMinutes ||
+                    currentMinutes < endMinutes) {
                   hasActiveTrigger = true;
                 }
               }
@@ -156,12 +195,13 @@ bool getDoNotDisturb() {
       }
       // Not manually enabled, not enabled due to schedule
       return hasActiveTrigger;
-    }
-    @catch (NSException *error) {
+    } @catch (NSException *error) {
       NSLog(@"Failed to detect DND status: %@", error);
     }
     return false;
-  } 
+  }
   NSLog(@"MacOS prior BigSur(Mohave, Catalina, ...) detected");
-  return [[[[NSUserDefaults alloc] initWithSuiteName:@"com.apple.notificationcenterui"] objectForKey:@"doNotDisturb"] boolValue];
+  return [[[[NSUserDefaults alloc]
+      initWithSuiteName:@"com.apple.notificationcenterui"]
+      objectForKey:@"doNotDisturb"] boolValue];
 }


### PR DESCRIPTION
Hello,
@felixrieseberg @MarshallOfSound 

com.apple.ncprefs approach no longer works for Monterey. 

And actually there could be issue - if you updated to Monterey with DND turned on - ncprefs will still have userPrefs with DND enabled value (MacOS even not erased it on update).

During some investigation i found that there is "~/Library/DoNotDisturb/DB/", which contains all DND setting state. 
It updates immediately after manual/scheduled change of DND status.  So, for Monterey i added logic to read it instead of ncprefs.

Probably its not proper fix, but anyway it works. 
Feel free to provide better solution.