### PR TITLE
fix(ensure-sdk): avoid ensure on windows

### DIFF
--- a/ensure-sdk.js
+++ b/ensure-sdk.js
@@ -1,5 +1,9 @@
 const { execSync } = require("child_process");
 
+if (process.platform !== "darwin") {
+  return;
+}
+
 console.log(
   `Trying to ensure that you have the right SDK version (> 11.0) to build this package. We'll run "xcrun --show-sdk-version" and compare the output. To disable this check, set the environment variable MACOS_NOTIFICATION_STATE_NO_SDK_CHECK`
 );

--- a/ensure-sdk.js
+++ b/ensure-sdk.js
@@ -1,15 +1,11 @@
 const { execSync } = require("child_process");
 
-if (process.platform !== "darwin") {
-  return;
-}
-
 console.log(
   `Trying to ensure that you have the right SDK version (> 11.0) to build this package. We'll run "xcrun --show-sdk-version" and compare the output. To disable this check, set the environment variable MACOS_NOTIFICATION_STATE_NO_SDK_CHECK`
 );
 
 function check() {
-  if (process.env.MACOS_NOTIFICATION_STATE_NO_SDK_CHECK) {
+  if (process.env.MACOS_NOTIFICATION_STATE_NO_SDK_CHECK || process.platform !== "darwin") {
     return;
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "macos-notification-state",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "macOS notification state as a native node addon",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
quick fix for #28 


i see there is env.MACOS_NOTIFICATION_STATE_NO_SDK_CHECK to avoid - but it requires update for windows built environment - which is not comfortable as was before and requires additional effort

so to simplify this - just avoid check logic if platform not darwin