### PR TITLE
feat(macOS13): support FocusStatus on macOS13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 3.0.0
+- Support macOS 13 - use FocusStatus API to detect Focus mode active or not
+(its internally compute final state - include checking for personal focus schedule and allowed apps)
+- details here: https://developer.apple.com/documentation/usernotifications/handling_communication_notifications_and_focus_status_updates
+
+Changed API: getDoNotDisturb now return Promise<boolean>
+
 # 2.0.2
 - Support macOS 13, fixing a "if version === 12" check
 

--- a/binding.gyp
+++ b/binding.gyp
@@ -8,6 +8,7 @@
           "sources": [
             "lib/notificationstate-query.cc", 
             "lib/do-not-disturb.mm", 
+            "lib/macos-version.mm",
             "lib/dnd/old-macos-dnd.mm", 
             "lib/dnd/bigsur-macos-dnd.mm", 
             "lib/dnd/monterey-macos-dnd.mm"
@@ -15,6 +16,20 @@
           "xcode_settings": {
               "OTHER_CPLUSPLUSFLAGS": ["-std=c++17", "-stdlib=libc++", "-mmacosx-version-min=10.7"],
               "OTHER_LDFLAGS": ["-framework CoreFoundation -framework CoreGraphics"]
+          }
+        }],
+      ]
+    },
+    {
+      "target_name": "focuscenter",
+      "sources": [ "lib/focus-center.mm" ],
+      "conditions": [
+        ['OS=="mac"', {
+          'include_dirs' : [ "<!@(node -p \"require('node-addon-api').include\")" ],
+          'defines': [ 'NAPI_DISABLE_CPP_EXCEPTIONS' ],
+          "xcode_settings": {
+              "OTHER_CPLUSPLUSFLAGS": ["-std=c++17", "-stdlib=libc++", "-mmacosx-version-min=10.7"],
+              "OTHER_LDFLAGS": ["-framework Foundation -weak_framework Intents"]
           }
         }],
       ]

--- a/ensure-sdk.js
+++ b/ensure-sdk.js
@@ -1,25 +1,25 @@
-const { execSync } = require("child_process");
+const { execSync } = require('child_process')
 
 console.log(
-  `Trying to ensure that you have the right SDK version (> 11.0) to build this package. We'll run "xcrun --show-sdk-version" and compare the output. To disable this check, set the environment variable MACOS_NOTIFICATION_STATE_NO_SDK_CHECK`
-);
+  'Trying to ensure that you have the right SDK version (> 11.0) to build this package. We\'ll run "xcrun --show-sdk-version" and compare the output. To disable this check, set the environment variable MACOS_NOTIFICATION_STATE_NO_SDK_CHECK'
+)
 
-function check() {
-  if (process.env.MACOS_NOTIFICATION_STATE_NO_SDK_CHECK || process.platform !== "darwin") {
-    return;
+function check () {
+  if (process.env.MACOS_NOTIFICATION_STATE_NO_SDK_CHECK || process.platform !== 'darwin') {
+    return
   }
 
   const result = parseFloat(
-    execSync("xcrun --show-sdk-version").toString().trim()
-  );
+    execSync('xcrun --show-sdk-version').toString().trim()
+  )
 
   if (result < 11) {
     throw new Error(
       `You do not have the required minimum macOS SDK. Version found: ${result}`
-    );
+    )
   }
 
-  console.log(`Test passed, found ${result}`);
+  console.log(`Test passed, found ${result}`)
 }
 
-check();
+check()

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 declare module 'macos-notification-state' {
   export function getNotificationState(): 'UNKNOWN_ERROR' | SessionState | 'DO_NOT_DISTURB';
   export function getSessionState():  SessionState;
-  export function getDoNotDisturb(): boolean;
+  export function getDoNotDisturb(): Promise<boolean>;
   export type SessionState = 'SESSION_SCREEN_IS_LOCKED' | 'SESSION_ON_CONSOLE_KEY' | 'UNKNOWN';
 }

--- a/lib/do-not-disturb.mm
+++ b/lib/do-not-disturb.mm
@@ -1,21 +1,20 @@
 #import "dnd/bigsur-macos-dnd.h"
 #import "dnd/monterey-macos-dnd.h"
 #import "dnd/old-macos-dnd.h"
+#import "macos-version.h"
 #import <Foundation/Foundation.h>
 
 bool getDoNotDisturb() {
-  NSOperatingSystemVersion version =
-      [[NSProcessInfo processInfo] operatingSystemVersion];
-  bool isBigSur = version.majorVersion == 11 ||
-                  (version.majorVersion == 10 && version.minorVersion > 15);
-  bool isAtLeastMonterey = version.majorVersion >= 12;
+  auto majorVersion = getOSVersion();
+  bool isBigSur = majorVersion == 11;
+  bool isMonterey = majorVersion == 12;
 
   @try {
     if (isBigSur) {
       return getBigSurMacOSDND();
-    } else if (isAtLeastMonterey) {
+    } else if (isMonterey) {
       return [MontereyDND isEnabled];
-    } else {
+    } else if (majorVersion < 11) {
       return getOldMacOSDND();
     }
   } @catch (NSException *error) {

--- a/lib/focus-center.mm
+++ b/lib/focus-center.mm
@@ -1,0 +1,69 @@
+#import "napi.h"
+#import <Foundation/Foundation.h>
+
+#if __has_include("Intents/Intents.h")
+#import <Intents/Intents.h>
+#endif
+
+// Requirements for make it work:
+// 1. add entitlement <key>com.apple.developer.usernotifications.communication</key><true/>
+// 2. create ProvisioningProfile (if have not yet) - allow Communication Notification service access
+// 3. "NSFocusStatusUsageDescription": "some description", - in order to show Request access to FocusStatus
+// note: for reset use "tccutil reset FocusStatus".
+
+Napi::Value NoOp(const Napi::CallbackInfo &info) {
+  return info.Env().Undefined();
+}
+Napi::Promise GetFocusStatus(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  Napi::Promise::Deferred deferred = Napi::Promise::Deferred::New(env);
+  Napi::ThreadSafeFunction ts_fn = Napi::ThreadSafeFunction::New(
+      env, Napi::Function::New(env, NoOp), "focusStatusCallback", 0, 1,
+      [](Napi::Env) {});
+
+#if __has_include("Intents/Intents.h")
+  NSLog(@"MacosNotificationState: FocusStatusCenter API available");
+
+  [[INFocusStatusCenter defaultCenter]
+      requestAuthorizationWithCompletionHandler:^(
+          INFocusStatusAuthorizationStatus status) {
+        NSLog(@"MacosNotificationState: INFocusStatusAuthorizationStatus: %ld",
+              status);
+        auto isAuthorized =
+            status == INFocusStatusAuthorizationStatusAuthorized;
+        // request FocusStatus.isFocused
+        // calc real state according to schedule/personal/dnd focus modes also ensure allowed apps
+        auto isFocused =
+            [[[INFocusStatusCenter defaultCenter] focusStatus] isFocused];
+
+        NSLog(@"MacosNotificationState: isFocused: %@", isFocused);
+
+        auto callback = [=](Napi::Env env, Napi::Function noop_cb) {
+          if (isAuthorized) {
+            // resolve Promise with value
+            deferred.Resolve(Napi::Number::New(env, [isFocused intValue]));
+          } else {
+            NSString *errorStatus = [NSString
+                stringWithFormat:
+                    @"FocusStatus access not authorized, status: %ld", status];
+            deferred.Reject(
+                Napi::TypeError::New(
+                    env, Napi::String::New(env, [errorStatus UTF8String]))
+                    .Value());
+          }
+        };
+        ts_fn.BlockingCall(callback);
+      }];
+#endif
+  NSLog(@"MacosNotificationState: promise created");
+  return deferred.Promise();
+}
+
+Napi::Object Init(Napi::Env env, Napi::Object exports) {
+#if __has_include("Intents/Intents.h")
+  exports.Set(Napi::String::New(env, "getFocusStatus"),
+              Napi::Function::New(env, GetFocusStatus));
+#endif
+  return exports;
+}
+NODE_API_MODULE(target_name, Init)

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,30 +1,30 @@
-const addon = require('bindings')('notificationstate')
+const notificationState = require("bindings")("notificationstate");
 
 /**
  * Returns the status, either 'UNKNOWN_ERROR', 'UNKNOWN', 'SESSION_SCREEN_IS_LOCKED','SESSION_ON_CONSOLE_KEY', or 'DO_NOT_DISTURB'. If DND is enabled, the session state isn't checked.
  *
  * @returns {string} USER_NOTIFICATION_STATE
  */
-function getNotificationState () {
-  if (process.platform !== 'darwin') {
-    throw new Error('macos-notification-state only works on macOS')
+function getNotificationState() {
+  if (process.platform !== "darwin") {
+    throw new Error("macos-notification-state only works on macOS");
   }
 
   const USER_NOTIFICATION_STATE = [
-    'UNKNOWN',
-    'SESSION_SCREEN_IS_LOCKED',
-    'SESSION_ON_CONSOLE_KEY',
-    'DO_NOT_DISTURB'
-  ]
+    "UNKNOWN",
+    "SESSION_SCREEN_IS_LOCKED",
+    "SESSION_ON_CONSOLE_KEY",
+    "DO_NOT_DISTURB",
+  ];
 
-  const dnd = getDoNotDisturb()
-  if (dnd) return USER_NOTIFICATION_STATE[3]
+  const dnd = getDoNotDisturb();
+  if (dnd) return USER_NOTIFICATION_STATE[3];
 
-  const ss = addon.getNotificationState()
+  const ss = notificationState.getNotificationState();
   if (USER_NOTIFICATION_STATE[ss]) {
-    return USER_NOTIFICATION_STATE[ss]
+    return USER_NOTIFICATION_STATE[ss];
   } else {
-    return 'UNKNOWN_ERROR'
+    return "UNKNOWN_ERROR";
   }
 }
 
@@ -33,21 +33,23 @@ function getNotificationState () {
  *
  * @returns {string} sessionState
  */
-function getSessionState () {
-  if (process.platform !== 'darwin') {
-    throw new Error('macos-notification-state only works on macOS')
+function getSessionState() {
+  if (process.platform !== "darwin") {
+    throw new Error("macos-notification-state only works on macOS");
   }
 
-  const result = addon.getNotificationState()
+  const result = notificationState.getNotificationState();
 
   if (result === -1) {
-    throw new Error('Getting session state for macOS encountered unknown error')
+    throw new Error(
+      "Getting session state for macOS encountered unknown error"
+    );
   } else if (result === 1) {
-    return 'SESSION_SCREEN_IS_LOCKED'
+    return "SESSION_SCREEN_IS_LOCKED";
   } else if (result === 2) {
-    return 'SESSION_ON_CONSOLE_KEY'
+    return "SESSION_ON_CONSOLE_KEY";
   } else {
-    return 'UNKNOWN'
+    return "UNKNOWN";
   }
 }
 
@@ -56,24 +58,32 @@ function getSessionState () {
  *
  * @returns {boolean} isDoNotDisturb
  */
-function getDoNotDisturb () {
-  if (process.platform !== 'darwin') {
-    throw new Error('macos-notification-state only works on macOS')
+function getDoNotDisturb() {
+  if (process.platform !== "darwin") {
+    throw new Error("macos-notification-state only works on macOS");
   }
+  return new Promise((resolve, reject) => {
+    const dnd = notificationState.getDoNotDisturb();
 
-  const dnd = addon.getDoNotDisturb()
-
-  if (dnd === -1) {
-    throw new Error('Getting do not disturb for macOS encountered unknown error')
-  } else if (dnd === 1) {
-    return true
-  } else {
-    return false
-  }
+    if (dnd === -1) {
+      // will return if macos > 12
+      const focusCenter = require("bindings")("focuscenter");
+      if (!!focusCenter.getFocusStatus) {
+        focusCenter
+          .getFocusStatus()
+          .then((isFocused) => resolve(isFocused === 1))
+          .catch((e) => reject(e));
+      } else {
+        reject(new Error("getFocusStatus not supported"));
+      }
+    } else {
+      return resolve(dnd === 1);
+    }
+  });
 }
 
 module.exports = {
-  getDoNotDisturb: getDoNotDisturb,
-  getNotificationState: getNotificationState,
-  getSessionState: getSessionState
-}
+  getDoNotDisturb,
+  getNotificationState,
+  getSessionState,
+};

--- a/lib/macos-version.h
+++ b/lib/macos-version.h
@@ -1,0 +1,1 @@
+int getOSVersion();

--- a/lib/macos-version.mm
+++ b/lib/macos-version.mm
@@ -1,0 +1,13 @@
+#import <Foundation/Foundation.h>
+
+int getOSVersion() {
+  NSOperatingSystemVersion version =
+      [[NSProcessInfo processInfo] operatingSystemVersion];
+  bool isBigSur = version.majorVersion == 11 ||
+                  (version.majorVersion == 10 && version.minorVersion > 15);
+
+  if (isBigSur) {
+    return 11;
+  }
+  return version.majorVersion;
+}

--- a/lib/notificationstate.cc
+++ b/lib/notificationstate.cc
@@ -1,36 +1,36 @@
 #define NAPI_VERSION 3
 #include <node_api.h>
 
-#define NAPI_CALL(env, call)                                      \
-  do {                                                            \
-    napi_status status = (call);                                  \
-    if (status != napi_ok) {                                      \
-      const napi_extended_error_info* error_info = NULL;          \
-      napi_get_last_error_info((env), &error_info);               \
-      bool is_pending;                                            \
-      napi_is_exception_pending((env), &is_pending);              \
-      if (!is_pending) {                                          \
-        const char* message = (error_info->error_message == NULL) \
-            ? "empty error message"                               \
-            : error_info->error_message;                          \
-        napi_throw_error((env), NULL, message);                   \
-        return NULL;                                              \
-      }                                                           \
-    }                                                             \
-  } while(0)
-
+#define NAPI_CALL(env, call)                                                   \
+  do {                                                                         \
+    napi_status status = (call);                                               \
+    if (status != napi_ok) {                                                   \
+      const napi_extended_error_info *error_info = NULL;                       \
+      napi_get_last_error_info((env), &error_info);                            \
+      bool is_pending;                                                         \
+      napi_is_exception_pending((env), &is_pending);                           \
+      if (!is_pending) {                                                       \
+        const char *message = (error_info->error_message == NULL)              \
+                                  ? "empty error message"                      \
+                                  : error_info->error_message;                 \
+        napi_throw_error((env), NULL, message);                                \
+        return NULL;                                                           \
+      }                                                                        \
+    }                                                                          \
+  } while (0)
 
 #ifdef __APPLE__
-#include "notificationstate-query.h"
 #include "do-not-disturb.h"
+#include "macos-version.h"
+#include "notificationstate-query.h"
 #endif
 
 static napi_value QueryUserSessionState(napi_env env, napi_callback_info info) {
   int returnValue = -1;
 
-  #ifdef __APPLE__
+#ifdef __APPLE__
   returnValue = queryUserSessionState();
-  #endif
+#endif
 
   napi_value result;
   NAPI_CALL(env, napi_create_int32(env, returnValue, &result));
@@ -40,15 +40,17 @@ static napi_value QueryUserSessionState(napi_env env, napi_callback_info info) {
 static napi_value GetDoNotDisturb(napi_env env, napi_callback_info info) {
   int returnValue = -1;
 
-  #ifdef __APPLE__
-  bool dnd = getDoNotDisturb();
-
-  if (dnd) {
-    returnValue = 1;
-  } else {
-    returnValue = 0;
+#ifdef __APPLE__
+  auto majorVersion = getOSVersion();
+  if (majorVersion < 13) {
+    bool dnd = getDoNotDisturb();
+    if (dnd) {
+      returnValue = 1;
+    } else {
+      returnValue = 0;
+    }
   }
-  #endif
+#endif
 
   napi_value result;
   NAPI_CALL(env, napi_create_int32(env, returnValue, &result));
@@ -59,13 +61,19 @@ NAPI_MODULE_INIT() {
   napi_value result = nullptr;
   NAPI_CALL(env, napi_create_object(env, &result));
 
-  #ifdef __APPLE__
+#ifdef __APPLE__
   napi_value exported_function;
-  NAPI_CALL(env, napi_create_function(env, "getNotificationState", NAPI_AUTO_LENGTH, QueryUserSessionState, NULL, &exported_function));
-  NAPI_CALL(env, napi_set_named_property(env, result, "getNotificationState", exported_function));
+  NAPI_CALL(env, napi_create_function(env, "getNotificationState",
+                                      NAPI_AUTO_LENGTH, QueryUserSessionState,
+                                      NULL, &exported_function));
+  NAPI_CALL(env, napi_set_named_property(env, result, "getNotificationState",
+                                         exported_function));
 
-  NAPI_CALL(env, napi_create_function(env, "getDoNotDisturb", NAPI_AUTO_LENGTH, GetDoNotDisturb, NULL, &exported_function));
-  NAPI_CALL(env, napi_set_named_property(env, result, "getDoNotDisturb", exported_function));
-  #endif
+  NAPI_CALL(env,
+            napi_create_function(env, "getDoNotDisturb", NAPI_AUTO_LENGTH,
+                                 GetDoNotDisturb, NULL, &exported_function));
+  NAPI_CALL(env, napi_set_named_property(env, result, "getDoNotDisturb",
+                                         exported_function));
+#endif
   return result;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "macos-notification-state",
-  "version": "2.0.2",
+  "version": "3.0.0",
   "description": "macOS notification state as a native node addon",
   "main": "lib/index.js",
   "scripts": {
@@ -16,7 +16,8 @@
     }
   ],
   "dependencies": {
-    "bindings": "^1.5.0"
+    "bindings": "^1.5.0",
+    "node-addon-api": "3.0.0"
   },
   "author": {
     "email": "felix@felixrieseberg.com",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1207,6 +1207,11 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
+node-addon-api@3.0.0:
+  version "3.0.0"
+  resolved "https://qanpm.qaintermedia.net/node-addon-api/-/node-addon-api-3.0.0.tgz#812446a1001a54f71663bed188314bba07e09247"
+  integrity sha512-sSHCgWfJ+Lui/u+0msF3oyCgvdkhxDbkCS6Q8uiJquzOimkJBvX6hl5aSSA7DR1XbMpdM8r7phjcF63sF4rkKg==
+
 normalize-package-data@^2.3.2:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"


### PR DESCRIPTION
Unfortunately fix from @MarshallOfSound in 2.0.2 works only if application granted "Full disk access" - its not good way.
So Ventura blocks access to ~/Library/DoNotDisturb/DB ....

In order to avoid this - made fix with approach described here:
https://developer.apple.com/documentation/usernotifications/handling_communication_notifications_and_focus_status_updates ( see Request Focus state section)


For macOS prior to 13 - all works as before, only on Ventura new logic will be used via INFocusStatusCenter

// Requirements for make it work:
// 1. add entitlement <key>com.apple.developer.usernotifications.communication</key><true/>
// 2. create ProvisioningProfile (if have not yet) - allow Communication Notification service access
// 3. should be added also "NSFocusStatusUsageDescription": "some description", - in order to show Request access to FocusStatus
// note: for reset use "tccutil reset FocusStatus".


@felixrieseberg @MarshallOfSound  - please review